### PR TITLE
#1: Deprecated use of 'webkitURL'

### DIFF
--- a/HttpWebcamLiveStream/Web/JavaScript/Camera.js
+++ b/HttpWebcamLiveStream/Web/JavaScript/Camera.js
@@ -29,10 +29,9 @@ function GetVideoFrames() {
 }
 
 function createObjectURL(blob) {
-    if (window.webkitURL) {
-        return window.webkitURL.createObjectURL(blob);
-    } else if (window.URL && window.URL.createObjectURL) {
-        return window.URL.createObjectURL(blob);
+    var URL = window.URL || window.webkitURL;
+    if (URL && URL.createObjectURL) {
+        return URL.createObjectURL(blob);
     } else {
         return null;
     }


### PR DESCRIPTION
Use 'URL' first. Fallback to 'webkitURL'.